### PR TITLE
Explicitly set the react-jsx version

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -7,6 +7,9 @@
     "dir": "src",
     "subdirs": true
   },
+  "reason": {
+    "react-jsx": 3
+  },
   "warnings": {
     "number": "+A",
     "error": "+A"


### PR DESCRIPTION
This fixes the issue as described here https://forum.rescript-lang.org/t/how-to-do-peer-dependencies-when-publishing-a-rescript-npm-package